### PR TITLE
Refactor API calculation and add strict integration test

### DIFF
--- a/src/main/java/dev/jpfurlan/resource/IntervalResource.java
+++ b/src/main/java/dev/jpfurlan/resource/IntervalResource.java
@@ -1,108 +1,24 @@
 package dev.jpfurlan.resource;
 
-import dev.jpfurlan.entity.Movie;
-import dev.jpfurlan.repository.MovieRepository;
+import dev.jpfurlan.service.ProducerIntervalService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 @Path("/producers/intervals")
 @Produces(MediaType.APPLICATION_JSON)
 public class IntervalResource {
 
     @Inject
-    MovieRepository repo;
+    ProducerIntervalService service;
 
     @GET
     public Map<String, List<Map<String, Object>>> getIntervals() {
-
-        List<Movie> wins = repo.findWinnersOrdered();
-        System.out.println("Filmes vencedores:"
-                + wins.size() + " - " + wins);
-
-        Map<String, List<Integer>> yearsByProducer = new HashMap<>();
-
-        for (Movie m : wins) {
-            String[] parts = m.producers.split("\\s+and\\s+|,");
-
-            for (String raw : parts) {
-                String producer = raw.trim();
-                yearsByProducer
-                        .computeIfAbsent(producer, k -> new ArrayList<>())
-                        .add(m.releaseYear);
-            }
-        }
-        System.out.println("yearsByProducer: " + yearsByProducer);
-
-        List<Map<String, Object>> allIntervals = new ArrayList<>();
-        System.out.println("allIntervals para registros de intervalo");
-
-        for (var entry : yearsByProducer.entrySet()) {
-            String producer = entry.getKey();
-            List<Integer> years = entry.getValue();
-
-            if (years.size() < 2) {
-                continue;
-            }
-
-            Collections.sort(years);
-
-            for (int i = 1; i < years.size(); i++) {
-                int previousWin  = years.get(i - 1);
-                int followingWin = years.get(i);
-                int interval     = followingWin - previousWin;
-
-                Map<String, Object> record = new HashMap<>();
-                record.put("producer",     producer);
-                record.put("previousWin",  previousWin);
-                record.put("followingWin", followingWin);
-                record.put("interval",     interval);
-
-                allIntervals.add(record);
-                System.out.println(" Intervalo calculado: "
-                        + producer + ": " + previousWin + ": " + followingWin
-                        + " = " + interval + " anos");
-            }
-        }
-        System.out.println("Todos os intervalos calculados: " + allIntervals);
-
-        long minInterval = allIntervals.stream()
-                .mapToLong(e -> ((Number) e.get("interval")).longValue())
-                .min()
-                .orElse(0L);
-        long maxInterval = allIntervals.stream()
-                .mapToLong(e -> ((Number) e.get("interval")).longValue())
-                .max()
-                .orElse(0L);
-        System.out.println("minInterval = " + minInterval
-                + " | maxInterval = " + maxInterval);
-
-        List<Map<String, Object>> minList = new ArrayList<>();
-        List<Map<String, Object>> maxList = new ArrayList<>();
-        System.out.println("Separando registros em minList e maxList");
-
-        for (Map<String, Object> rec : allIntervals) {
-            long iv = ((Number) rec.get("interval")).longValue();
-            if (iv == minInterval) {
-                minList.add(rec);
-                System.out.println("min:" + rec);
-            }
-            if (iv == maxInterval) {
-                maxList.add(rec);
-                System.out.println("max:" + rec);
-            }
-        }
-
-        Map<String, List<Map<String, Object>>> response = Map.of(
-                "min", minList,
-                "max", maxList
-        );
-        System.out.println("getIntervals(): " + response + "\n");
-
-        return response;
+        return service.calculateIntervals();
     }
 }

--- a/src/main/java/dev/jpfurlan/service/ProducerIntervalService.java
+++ b/src/main/java/dev/jpfurlan/service/ProducerIntervalService.java
@@ -1,0 +1,91 @@
+package dev.jpfurlan.service;
+
+import dev.jpfurlan.entity.Movie;
+import dev.jpfurlan.repository.MovieRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.*;
+
+@ApplicationScoped
+public class ProducerIntervalService {
+
+    private static final Logger LOG = Logger.getLogger(ProducerIntervalService.class);
+
+    @Inject
+    MovieRepository repo;
+
+    public Map<String, List<Map<String, Object>>> calculateIntervals() {
+        List<Movie> wins = repo.findWinnersOrdered();
+        LOG.debugf("Filmes vencedores: %d - %s", wins.size(), wins);
+
+        Map<String, List<Integer>> yearsByProducer = new HashMap<>();
+        for (Movie m : wins) {
+            String[] parts = m.producers.split("\\s+and\\s+|,");
+            for (String raw : parts) {
+                String producer = raw.trim();
+                yearsByProducer
+                        .computeIfAbsent(producer, k -> new ArrayList<>())
+                        .add(m.releaseYear);
+            }
+        }
+        LOG.debugf("yearsByProducer: %s", yearsByProducer);
+
+        List<Map<String, Object>> allIntervals = new ArrayList<>();
+        for (var entry : yearsByProducer.entrySet()) {
+            String producer = entry.getKey();
+            List<Integer> years = entry.getValue();
+            if (years.size() < 2) {
+                continue;
+            }
+            Collections.sort(years);
+            for (int i = 1; i < years.size(); i++) {
+                int previousWin = years.get(i - 1);
+                int followingWin = years.get(i);
+                int interval = followingWin - previousWin;
+
+                Map<String, Object> record = new HashMap<>();
+                record.put("producer", producer);
+                record.put("previousWin", previousWin);
+                record.put("followingWin", followingWin);
+                record.put("interval", interval);
+
+                allIntervals.add(record);
+                LOG.debugf("Intervalo calculado: %s: %d: %d = %d anos", producer, previousWin, followingWin, interval);
+            }
+        }
+        LOG.debugf("Todos os intervalos calculados: %s", allIntervals);
+
+        long minInterval = allIntervals.stream()
+                .mapToLong(e -> ((Number) e.get("interval")).longValue())
+                .min()
+                .orElse(0L);
+        long maxInterval = allIntervals.stream()
+                .mapToLong(e -> ((Number) e.get("interval")).longValue())
+                .max()
+                .orElse(0L);
+        LOG.debugf("minInterval = %d | maxInterval = %d", minInterval, maxInterval);
+
+        List<Map<String, Object>> minList = new ArrayList<>();
+        List<Map<String, Object>> maxList = new ArrayList<>();
+        for (Map<String, Object> rec : allIntervals) {
+            long iv = ((Number) rec.get("interval")).longValue();
+            if (iv == minInterval) {
+                minList.add(rec);
+                LOG.debugf("min: %s", rec);
+            }
+            if (iv == maxInterval) {
+                maxList.add(rec);
+                LOG.debugf("max: %s", rec);
+            }
+        }
+
+        Map<String, List<Map<String, Object>>> response = Map.of(
+                "min", minList,
+                "max", maxList
+        );
+        LOG.debugf("calculateIntervals(): %s", response);
+        return response;
+    }
+}

--- a/src/test/java/dev/jpfurlan/IntervalResourceTest.java
+++ b/src/test/java/dev/jpfurlan/IntervalResourceTest.java
@@ -1,21 +1,32 @@
 package dev.jpfurlan;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.path.json.JsonPath;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.greaterThan;
 
 @QuarkusTest
 public class IntervalResourceTest {
 
     @Test
-    public void shouldReturnIntervals() {
-        given()
+    public void shouldReturnIntervalsFromDefaultFile() throws IOException {
+        String expectedJson = Files.readString(Path.of("src/test/resources/expected-intervals.json"));
+        Map<String, Object> expected = new JsonPath(expectedJson).getMap("$");
+
+        String response = given()
                 .when().get("/producers/intervals")
                 .then()
                 .statusCode(200)
-                .body("min.size()", greaterThan(0))
-                .body("max.size()", greaterThan(0));
+                .extract().asString();
+
+        Map<String, Object> actual = new JsonPath(response).getMap("$");
+        Assertions.assertEquals(expected, actual);
     }
 }

--- a/src/test/resources/expected-intervals.json
+++ b/src/test/resources/expected-intervals.json
@@ -1,0 +1,18 @@
+{
+  "min": [
+    {
+      "producer": "Joel Silver",
+      "previousWin": 1990,
+      "followingWin": 1991,
+      "interval": 1
+    }
+  ],
+  "max": [
+    {
+      "producer": "Matthew Vaughn",
+      "previousWin": 2002,
+      "followingWin": 2015,
+      "interval": 13
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- move interval calculation from REST resource to a new service layer
- replace `System.out.println` with a logging solution
- update REST resource to delegate work to the service
- create strict integration test validating response against an expected file
- add expected JSON result used by the test

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862f9303aac8329b535b4e67e5f9dcb