### PR TITLE
Refactor interval calculation into smaller classes

### DIFF
--- a/src/main/java/dev/jpfurlan/service/IntervalsExtractor.java
+++ b/src/main/java/dev/jpfurlan/service/IntervalsExtractor.java
@@ -1,0 +1,53 @@
+package dev.jpfurlan.service;
+
+import dev.jpfurlan.entity.Movie;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.logging.Logger;
+
+import java.util.*;
+
+@ApplicationScoped
+public class IntervalsExtractor {
+
+    private static final Logger LOG = Logger.getLogger(IntervalsExtractor.class);
+
+    public List<Map<String, Object>> extract(List<Movie> wins) {
+        Map<String, List<Integer>> yearsByProducer = new HashMap<>();
+        for (Movie m : wins) {
+            String[] parts = m.producers.split("\\s+and\\s+|,");
+            for (String raw : parts) {
+                String producer = raw.trim();
+                yearsByProducer
+                        .computeIfAbsent(producer, k -> new ArrayList<>())
+                        .add(m.releaseYear);
+            }
+        }
+        LOG.debugf("yearsByProducer: %s", yearsByProducer);
+
+        List<Map<String, Object>> intervals = new ArrayList<>();
+        for (var entry : yearsByProducer.entrySet()) {
+            String producer = entry.getKey();
+            List<Integer> years = entry.getValue();
+            if (years.size() < 2) {
+                continue;
+            }
+            Collections.sort(years);
+            for (int i = 1; i < years.size(); i++) {
+                int previous = years.get(i - 1);
+                int following = years.get(i);
+                int interval = following - previous;
+
+                Map<String, Object> rec = new HashMap<>();
+                rec.put("producer", producer);
+                rec.put("previousWin", previous);
+                rec.put("followingWin", following);
+                rec.put("interval", interval);
+
+                intervals.add(rec);
+                LOG.debugf("Intervalo calculado: %s: %d: %d = %d anos", producer, previous, following, interval);
+            }
+        }
+        LOG.debugf("Todos os intervalos calculados: %s", intervals);
+        return intervals;
+    }
+}

--- a/src/main/java/dev/jpfurlan/service/IntervalsSummary.java
+++ b/src/main/java/dev/jpfurlan/service/IntervalsSummary.java
@@ -1,0 +1,45 @@
+package dev.jpfurlan.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.logging.Logger;
+
+import java.util.*;
+
+@ApplicationScoped
+public class IntervalsSummary {
+
+    private static final Logger LOG = Logger.getLogger(IntervalsSummary.class);
+
+    public Map<String, List<Map<String, Object>>> summarize(List<Map<String, Object>> allIntervals) {
+        long minInterval = allIntervals.stream()
+                .mapToLong(e -> ((Number) e.get("interval")).longValue())
+                .min()
+                .orElse(0L);
+        long maxInterval = allIntervals.stream()
+                .mapToLong(e -> ((Number) e.get("interval")).longValue())
+                .max()
+                .orElse(0L);
+        LOG.debugf("minInterval = %d | maxInterval = %d", minInterval, maxInterval);
+
+        List<Map<String, Object>> minList = new ArrayList<>();
+        List<Map<String, Object>> maxList = new ArrayList<>();
+        for (Map<String, Object> rec : allIntervals) {
+            long iv = ((Number) rec.get("interval")).longValue();
+            if (iv == minInterval) {
+                minList.add(rec);
+                LOG.debugf("min: %s", rec);
+            }
+            if (iv == maxInterval) {
+                maxList.add(rec);
+                LOG.debugf("max: %s", rec);
+            }
+        }
+
+        Map<String, List<Map<String, Object>>> response = Map.of(
+                "min", minList,
+                "max", maxList
+        );
+        LOG.debugf("summarize(): %s", response);
+        return response;
+    }
+}

--- a/src/main/java/dev/jpfurlan/service/ProducerIntervalService.java
+++ b/src/main/java/dev/jpfurlan/service/ProducerIntervalService.java
@@ -4,88 +4,25 @@ import dev.jpfurlan.entity.Movie;
 import dev.jpfurlan.repository.MovieRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.jboss.logging.Logger;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 @ApplicationScoped
 public class ProducerIntervalService {
 
-    private static final Logger LOG = Logger.getLogger(ProducerIntervalService.class);
-
     @Inject
     MovieRepository repo;
 
+    @Inject
+    IntervalsExtractor extractor;
+
+    @Inject
+    IntervalsSummary summary;
+
     public Map<String, List<Map<String, Object>>> calculateIntervals() {
         List<Movie> wins = repo.findWinnersOrdered();
-        LOG.debugf("Filmes vencedores: %d - %s", wins.size(), wins);
-
-        Map<String, List<Integer>> yearsByProducer = new HashMap<>();
-        for (Movie m : wins) {
-            String[] parts = m.producers.split("\\s+and\\s+|,");
-            for (String raw : parts) {
-                String producer = raw.trim();
-                yearsByProducer
-                        .computeIfAbsent(producer, k -> new ArrayList<>())
-                        .add(m.releaseYear);
-            }
-        }
-        LOG.debugf("yearsByProducer: %s", yearsByProducer);
-
-        List<Map<String, Object>> allIntervals = new ArrayList<>();
-        for (var entry : yearsByProducer.entrySet()) {
-            String producer = entry.getKey();
-            List<Integer> years = entry.getValue();
-            if (years.size() < 2) {
-                continue;
-            }
-            Collections.sort(years);
-            for (int i = 1; i < years.size(); i++) {
-                int previousWin = years.get(i - 1);
-                int followingWin = years.get(i);
-                int interval = followingWin - previousWin;
-
-                Map<String, Object> record = new HashMap<>();
-                record.put("producer", producer);
-                record.put("previousWin", previousWin);
-                record.put("followingWin", followingWin);
-                record.put("interval", interval);
-
-                allIntervals.add(record);
-                LOG.debugf("Intervalo calculado: %s: %d: %d = %d anos", producer, previousWin, followingWin, interval);
-            }
-        }
-        LOG.debugf("Todos os intervalos calculados: %s", allIntervals);
-
-        long minInterval = allIntervals.stream()
-                .mapToLong(e -> ((Number) e.get("interval")).longValue())
-                .min()
-                .orElse(0L);
-        long maxInterval = allIntervals.stream()
-                .mapToLong(e -> ((Number) e.get("interval")).longValue())
-                .max()
-                .orElse(0L);
-        LOG.debugf("minInterval = %d | maxInterval = %d", minInterval, maxInterval);
-
-        List<Map<String, Object>> minList = new ArrayList<>();
-        List<Map<String, Object>> maxList = new ArrayList<>();
-        for (Map<String, Object> rec : allIntervals) {
-            long iv = ((Number) rec.get("interval")).longValue();
-            if (iv == minInterval) {
-                minList.add(rec);
-                LOG.debugf("min: %s", rec);
-            }
-            if (iv == maxInterval) {
-                maxList.add(rec);
-                LOG.debugf("max: %s", rec);
-            }
-        }
-
-        Map<String, List<Map<String, Object>>> response = Map.of(
-                "min", minList,
-                "max", maxList
-        );
-        LOG.debugf("calculateIntervals(): %s", response);
-        return response;
+        List<Map<String, Object>> intervals = extractor.extract(wins);
+        return summary.summarize(intervals);
     }
 }


### PR DESCRIPTION
## Summary
- split ProducerIntervalService by moving the interval processing into new helper classes
- add `IntervalsExtractor` for parsing movie wins
- add `IntervalsSummary` for selecting min and max intervals

## Testing
- `mvn test -q` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864fea6ab3c8329b82587b65e8e440a